### PR TITLE
feat: allow node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "loco-cli": "./dist/cli.js"
   },
   "engines": {
-    "node": "12.x || 14.x || 16.x"
+    "node": "12.x || 14.x || 16.x || 18.x"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Hi! 

I'm using [v2.0.0-rc2](https://github.com/robrechtme/loco-cli/releases/tag/v2.0.0-rc2) for a while now, great update!

I wanted to update to Node 18, but noticed this library supports untill v16.

This PR is to allow v18. I saw no testing in the github workflow, so I'm not sure if any additional change is needed.

