### PR TITLE
fix: take into account ignore-new and ignore-existing options in diff

### DIFF
--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -40,7 +40,8 @@ const push = async ({ yes, status, tag }: CommandOptions, program: Command) => {
   const remote = await apiPull(accessKey, pullOptions);
   const { added, deleted, updated, totalCount, deletedCount } = diff(
     remote,
-    local
+    local,
+    pushOptions
   );
 
   if (!totalCount || (!deleteAbsent && totalCount === deletedCount)) {

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -1,5 +1,5 @@
 import { detailedDiff } from "deep-object-diff";
-import { Translations } from "../../types";
+import { PushOptions, Translations } from "../../types";
 import { dotObject } from "./dotObject";
 
 interface DetailedDiff {
@@ -8,14 +8,20 @@ interface DetailedDiff {
   deleted: object;
 }
 
-export const diff = (local: Translations, remote: Translations) => {
+export const diff = (
+  local: Translations,
+  remote: Translations,
+  options?: PushOptions
+) => {
   const { added, updated, deleted } = detailedDiff(
     local,
     remote
   ) as DetailedDiff;
+  const ignoreAdded = options?.["ignore-new"];
+  const ignoreUpdated = options?.["ignore-existing"];
 
-  const addedRes = dotObject(added);
-  const updatedRes = dotObject(updated);
+  const addedRes = ignoreAdded ? {} : dotObject(added);
+  const updatedRes = ignoreUpdated ? {} : dotObject(updated);
   const deletedRes = dotObject(deleted);
   return {
     totalCount:

--- a/test/__snapshots__/diff.test.ts.snap
+++ b/test/__snapshots__/diff.test.ts.snap
@@ -19,3 +19,55 @@ exports[`returns diff 1`] = `
   "updatedCount": 1,
 }
 `;
+
+exports[`returns diff with options 1`] = `
+{
+  "added": {},
+  "addedCount": 0,
+  "deleted": {
+    "en.buttons.skip": undefined,
+    "en.title": undefined,
+  },
+  "deletedCount": 2,
+  "totalCount": 3,
+  "updated": {
+    "en.buttons.confirm": "Different translation local/remote",
+  },
+  "updatedCount": 1,
+}
+`;
+
+exports[`returns diff without new assets 1`] = `
+{
+  "added": {},
+  "addedCount": 0,
+  "deleted": {
+    "en.buttons.skip": undefined,
+    "en.title": undefined,
+  },
+  "deletedCount": 2,
+  "totalCount": 3,
+  "updated": {
+    "en.buttons.confirm": "Different translation local/remote",
+  },
+  "updatedCount": 1,
+}
+`;
+
+exports[`returns diff without updated assets 1`] = `
+{
+  "added": {
+    "en.body": "Newly added key remote in EN only",
+    "en.buttons.accept": "Newly added key deep remote in EN only",
+  },
+  "addedCount": 2,
+  "deleted": {
+    "en.buttons.skip": undefined,
+    "en.title": undefined,
+  },
+  "deletedCount": 2,
+  "totalCount": 4,
+  "updated": {},
+  "updatedCount": 0,
+}
+`;

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -5,3 +5,11 @@ import { local, remote } from "./mockdata/mockDiff";
 test("returns diff", () => {
   expect(diff(local, remote)).toMatchSnapshot();
 });
+
+test("returns diff without new assets", () => {
+  expect(diff(local, remote, { "ignore-new": true })).toMatchSnapshot();
+});
+
+test("returns diff without updated assets", () => {
+  expect(diff(local, remote, { "ignore-existing": true })).toMatchSnapshot();
+});


### PR DESCRIPTION
Take into account the ignore-new and ignore-existing options when using loco-cli push. 