### PR TITLE
feat: split key into namespaces just by first separator

### DIFF
--- a/src/util/namespaces.ts
+++ b/src/util/namespaces.ts
@@ -4,7 +4,7 @@ export const splitIntoNamespaces = (
 ) =>
   Object.entries(json).reduce<Record<string, object>>((acc, [key, value]) => {
     // Pull out the group name from the key
-    const chunks = key.split(separator);
+    const chunks = key.split(new RegExp(`${separator}(.*)`, 's'));
     const namespace = chunks.length > 1 ? chunks[0] : defaultNs;
     const assetKey = chunks.length > 1 ? chunks[1] : chunks[0];
 

--- a/test/namespaces.test.ts
+++ b/test/namespaces.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "vitest";
+import { splitIntoNamespaces } from "../src/util/namespaces";
+
+test("splitIntoNamespaces", async () => {
+    test("splits keys with colons into namespaces", async () => {
+
+        const input = splitIntoNamespaces({
+            "default:key": "value",
+            "group:key-with-colon:": "Value with colon:",
+            "another:group:key": "Value: with colon",
+        });
+
+        const expected = {
+            default: {
+                key: "value",
+            },
+            group: {
+                "key-with-colon:": "Value with colon:",
+            },
+            another: {
+                "group:key": "Value: with colon",
+            },
+        };
+
+        expect(input).toStrictEqual(expected);
+    });
+});


### PR DESCRIPTION
It allows use colon in the keys:
```
{
  "namespace:key:": "I am key with colon"
}
```
The issue could come from the locales where keys are generated by their value.
For example:
```
{
  "namespace:label:": "Label:"
}
```