### PR TITLE
Improve types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -103,7 +103,7 @@ export interface Config {
    */
   localesDir: string;
   /** @deprecated since v2 all languages are used */
-  defaultLanguage: string;
+  defaultLanguage?: string;
   /**
    * Organize translations into namespaces (default: `false`).
    * Set this flag to `true` when dividing translations into
@@ -113,11 +113,11 @@ export interface Config {
   /**
    * Options for the `loco-cli push` command.
    */
-  push: PushOptions;
+  push?: PushOptions;
   /**
    * Options for the `loco-cli pull` command.
    */
-  pull: PullOptions;
+  pull?: PullOptions;
 }
 
 export type Locale = string;


### PR DESCRIPTION
I've noticed this while writing my `.locorc.ts`:

```ts
import dotenv from 'dotenv'
import { Config } from 'loco-cli/types'

dotenv.config({ path: ['.env.local', '.env'] })

export const config: Config = { // <-- type raises TS error
  accessKey: process.env.LOCO_ACCESS_KEY as string,
  localesDir: 'src/management/i18n',
  namespaces: false,
  push: {
    'flag-new': 'provisional',
    'tag-new': process.env.npm_package_version,
    'delete-absent': false,
  },
}

export default config
```

```
Type '{ accessKey: string; localesDir: string; namespaces: false; push: { 'flag-new': string; 'tag-new': string | undefined; 'delete-absent': false; }; }' is missing the following properties from type 'Config': defaultLanguage, pullts(2739)
```
The config is copy pasted from documentation, I've only added types to the object and moved the Loco key to an `.env` file for project constraints.

But `defaultLanguage` is deprecated and both `PushOptions` and `PullOptions` have only optional keys. So it makes sense to make their respective keys in `Config` optional.

What do you think?