### PR TITLE
feat: add ignore-blank and flag-updated push options

### DIFF
--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -47,6 +47,7 @@ Options passed to the [Loco import API](https://localise.biz/api/docs/import/imp
 | `experimentalPushAll` | Upload all locales in a single API request instead of one per locale. Significantly improves performance for projects with many locales. |
 | `ignore-new` | New assets will NOT be added to the project |
 | `ignore-existing` | Existing assets will NOT be updated |
+| `ignore-blank` | Blank translations will NOT be imported |
 | `tag-new` | Tag new assets with given tags (comma separated) |
 | `tag-all` | Tag ALL assets in the file (comma separated) |
 | `untag-all` | Remove tags from matched assets (comma separated) |
@@ -56,6 +57,7 @@ Options passed to the [Loco import API](https://localise.biz/api/docs/import/imp
 | `untag-absent` | Remove tags from assets NOT in the file |
 | `delete-absent` | **Permanently delete** assets NOT in the file (use with caution) |
 | `flag-new` | Set flag on new non-empty translations |
+| `flag-updated` | Set flag on translations modified during import |
 
 ## Pull Options
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -48,6 +48,11 @@ export interface PushOptions {
    */
   'ignore-existing'?: boolean;
   /**
+   * Specify that blank translations should NOT be imported.
+   * @see https://localise.biz/api/docs/import/import#query
+   */
+  'ignore-blank'?: boolean;
+  /**
    * Tag any NEW assets added during the import with the given tags (comma separated).
    * @see https://localise.biz/api/docs/import/import#query
    */
@@ -92,6 +97,11 @@ export interface PushOptions {
    * @see https://localise.biz/api/docs/import/import#query
    */
   'flag-new'?: string;
+  /**
+   * Set this flag on any translations MODIFIED during import to the current locale.
+   * @see https://localise.biz/api/docs/import/import#query
+   */
+  'flag-updated'?: string;
 }
 
 export interface Config {


### PR DESCRIPTION
## Summary
- Add `ignore-blank` (boolean) — skips importing blank translation values
- Add `flag-updated` (string) — flags translations modified during import
- Document both options in the configuration reference

Both are valid Loco import API parameters that were previously missing from `PushOptions`. Verified working against the live Loco API in both per-locale and `experimentalPushAll` flows.

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (72 tests)
- [x] `pnpm lint` and `pnpm format:check` pass
- [x] Set `ignore-blank: true` in `.locorc.js` and confirm a push of an empty translation does not blank an existing non-empty value on Loco
- [x] Set `flag-updated: 'fuzzy'` and confirm modified translations get the `fuzzy` flag on Loco