### PR TITLE
feat: surface Loco import response message in push output

### DIFF
--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -98,8 +98,8 @@ const push = async (
     log.log(
       `Uploading ${localeCount} locale${localeCount > 1 ? 's' : ''} (experimentalPushAll)...`
     );
-    await apiPushAll(accessKey, flattenAllTranslations(local), pushOptions);
-    log.log('Done.');
+    const res = await apiPushAll(accessKey, flattenAllTranslations(local), pushOptions);
+    log.log(res.message);
   } else {
     const length = Object.keys(remote).length;
     const progressbar = new cliProgress.SingleBar({
@@ -109,11 +109,16 @@ const push = async (
       hideCursor: true
     });
     progressbar.start(length, 0);
+    const messages: [string, string][] = [];
     for (const [locale, translations] of Object.entries(local)) {
       progressbar.increment();
-      await apiPush(accessKey, locale, flattenTranslations(translations), pushOptions);
+      const res = await apiPush(accessKey, locale, flattenTranslations(translations), pushOptions);
+      messages.push([locale, res.message]);
     }
     progressbar.stop();
+    for (const [locale, message] of messages) {
+      log.log(`  ${chalk.bold(locale)}: ${message}`);
+    }
   }
 
   log.log();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import fetch from 'isomorphic-unfetch';
 import {
   FlatTranslations,
+  ImportResponse,
   ProjectLocale,
   PullOptions,
   PushOptions,
@@ -48,7 +49,7 @@ export const apiPush = (
   translations: FlatTranslations,
   options: PushOptions = {}
 ) =>
-  fetchApi<void>(
+  fetchApi<ImportResponse>(
     key,
     '/import/json',
     {
@@ -70,7 +71,7 @@ export const apiPushAll = (
   translations: Record<string, FlatTranslations>,
   options: PushOptions = {}
 ) =>
-  fetchApi<void>(
+  fetchApi<ImportResponse>(
     key,
     '/import/json',
     {

--- a/test/commands/push.test.ts
+++ b/test/commands/push.test.ts
@@ -58,8 +58,8 @@ beforeEach(() => {
   mockLog.error = vi.fn();
   mockLog.warn = vi.fn();
   mockLog.info = vi.fn();
-  mockApiPush.mockResolvedValue(undefined);
-  mockApiPushAll.mockResolvedValue(undefined);
+  mockApiPush.mockResolvedValue({ status: 200, message: '1 translation imported', locales: [] });
+  mockApiPushAll.mockResolvedValue({ status: 200, message: '1 translation imported', locales: [] });
   mockExit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
     throw new ExitError(code ?? 0);
   }) as never);
@@ -244,6 +244,41 @@ describe('push command', () => {
 
     expect(mockApiPushAll).toHaveBeenCalledTimes(1);
     expect(mockApiPush).not.toHaveBeenCalled();
+  });
+
+  test('logs API response message per locale (per-locale path)', async () => {
+    const local = { en: { hello: 'Hello' }, es: { hello: 'Hola' } };
+    const remote = { en: {}, es: {} };
+    mockReadFiles.mockResolvedValue(local);
+    mockApiPull.mockResolvedValue(remote);
+    mockApiPush
+      .mockResolvedValueOnce({ status: 200, message: '1 new asset', locales: [] })
+      .mockResolvedValueOnce({ status: 200, message: 'Nothing updated', locales: [] });
+    vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
+
+    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+
+    expect(mockLog.log).toHaveBeenCalledWith(expect.stringContaining('en'));
+    expect(mockLog.log).toHaveBeenCalledWith(expect.stringContaining('1 new asset'));
+    expect(mockLog.log).toHaveBeenCalledWith(expect.stringContaining('es'));
+    expect(mockLog.log).toHaveBeenCalledWith(expect.stringContaining('Nothing updated'));
+  });
+
+  test('logs API response message (experimentalPushAll path)', async () => {
+    const local = { en: { hello: 'Hello' }, es: { hello: 'Hola' } };
+    const remote = { en: {}, es: {} };
+    mockReadFiles.mockResolvedValue(local);
+    mockApiPull.mockResolvedValue(remote);
+    mockApiPushAll.mockResolvedValue({
+      status: 200,
+      message: '4 translations imported, 2 new assets',
+      locales: []
+    });
+    vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
+
+    await expect(push({ experimentalPushAll: true }, mockProgram)).rejects.toThrow(ExitError);
+
+    expect(mockLog.log).toHaveBeenCalledWith('4 translations imported, 2 new assets');
   });
 
   test('uses default per-locale push when experimentalPushAll is false', async () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -147,3 +147,10 @@ export type DiffRecord = Record<string, string | undefined>;
 export type ProjectLocale = {
   code: string;
 };
+
+/** Response shape from the Loco /import/json endpoint */
+export interface ImportResponse {
+  status: number;
+  message: string;
+  locales: ProjectLocale[];
+}


### PR DESCRIPTION
## Summary
- Replace generic `Done.` with the actual API message (e.g. `2 translations imported, 1 new asset`) so users see what each push accomplished
- Add `ImportResponse` type and use it as the return type of `apiPush` and `apiPushAll` (previously typed `void`)
- Per-locale path: collect each locale's message and print them after the progress bar
- `experimentalPushAll` path: print the single response message

## Test plan
- [x] `pnpm test` passes (74 tests)
- [x] `pnpm lint`, `pnpm format:check`, `pnpm build` pass
- [x] Run `loco-cli push` (per-locale) on a real project and confirm each locale's message appears under the bar
- [x] Run `loco-cli push` with `experimentalPushAll: true` and confirm the single multi-locale message is printed