### PR TITLE
fix: CLI flags override config file values

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -10,9 +10,9 @@ import { handleAsyncErrors } from './src/util/handleAsyncErrors';
 const program = new Command('loco-cli')
   .version(version)
   .option('-a, --access-key <key>', 'Loco API token')
-  .option('-d, --locales-dir <path>', 'The folder in which the translations are stored.', '.')
-  .option('-N, --namespaces', 'Organize translations into namespaces', false)
-  .option('-m, --max-files <number>', 'Maximum number of modified files to display', '20');
+  .option('-d, --locales-dir <path>', 'The folder in which the translations are stored.')
+  .option('-N, --namespaces', 'Organize translations into namespaces')
+  .option('-m, --max-files <number>', 'Maximum number of modified files to display');
 program
   .command('pull')
   .option('-y, --yes', 'Answer yes to all confirmation prompts', false)

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -10,6 +10,8 @@ Options can be passed as CLI flags or defined in a config file. Config files are
 - `.locorc.json`
 - `.locorc.js`
 
+When the same option is set in both places, the **CLI flag takes precedence** over the config file. This lets you keep shared defaults in the config file and override them per invocation.
+
 ## Example Config
 
 ```js

--- a/src/util/options.ts
+++ b/src/util/options.ts
@@ -30,10 +30,14 @@ export const getGlobalOptions = async (program: Command): Promise<Config> => {
       'The `defaultLanguage` option is deprecated. Starting from v2, all languages are used.'
     );
   }
-  // Note: merge deep when options will be nested
+  // CLI flags override config file values (only when explicitly provided).
+  // Note: merge deep when options will be nested.
+  const definedCliOptions = Object.fromEntries(
+    Object.entries(cliOptions).filter(([, v]) => v !== undefined)
+  );
   const mergedOptions: Partial<Config> = {
-    ...cliOptions,
-    ...fileOptions
+    ...fileOptions,
+    ...definedCliOptions
   };
 
   // Parse maxFiles as a number if it's provided as a string
@@ -43,9 +47,9 @@ export const getGlobalOptions = async (program: Command): Promise<Config> => {
 
   // accessKey is validated above; provide defaults for required fields
   return {
+    ...mergedOptions,
     accessKey: mergedOptions.accessKey!,
     localesDir: mergedOptions.localesDir ?? '.',
-    namespaces: mergedOptions.namespaces ?? false,
-    ...mergedOptions
+    namespaces: mergedOptions.namespaces ?? false
   };
 };

--- a/test/util/options.test.ts
+++ b/test/util/options.test.ts
@@ -63,9 +63,7 @@ describe('getGlobalOptions', () => {
     });
   });
 
-  test('file config overrides CLI options', async () => {
-    // Note: The implementation actually does fileOptions spread AFTER cliOptions,
-    // so file config takes precedence over CLI for shared keys
+  test('CLI options override file config', async () => {
     mockReadConfig.mockResolvedValue({
       accessKey: 'file-key',
       localesDir: './from-file',
@@ -76,7 +74,23 @@ describe('getGlobalOptions', () => {
       localesDir: './from-cli'
     }));
 
+    expect(result.localesDir).toBe('./from-cli');
+  });
+
+  test('file config is used when CLI flag is not provided', async () => {
+    mockReadConfig.mockResolvedValue({
+      accessKey: 'file-key',
+      localesDir: './from-file',
+      namespaces: true
+    });
+
+    const result = await getGlobalOptions(createMockProgram({
+      localesDir: undefined,
+      namespaces: undefined
+    }));
+
     expect(result.localesDir).toBe('./from-file');
+    expect(result.namespaces).toBe(true);
   });
 
   test('exits when no accessKey', async () => {


### PR DESCRIPTION
## Summary
Closes #28.

Restores the standard precedence followed by git, npm, eslint, prettier, tsc, kubectl, and most other CLIs: **CLI flags override config file values** when explicitly provided. Previously, file config silently won over CLI flags — making `-d, --locales-dir` (and other shared flags) effectively useless once a config file existed.

- Filter undefined CLI options before merging, so unset flags don't clobber config
- Remove default values from commander option definitions (they were always present in the merged result and made it impossible for config values to be used). Defaults still apply at the end of `getGlobalOptions`
- Replace the test that locked in the inverse (buggy) behavior with one asserting the correct precedence, plus a new test for the "config-only" path
- Document the precedence rule in the configuration page

## Test plan
- [x] `pnpm test` passes (73 tests)
- [x] `pnpm lint`, `pnpm format:check`, `pnpm build` pass
- [x] With `localesDir` set to one path in the config and `-d <other>` on the CLI, the CLI value is used
- [x] With `localesDir` only in the config (no `-d`), the config value is still used
- [x] With nothing set anywhere, defaults to `.`