### PR TITLE
fix: error when Loco silently drops a push (e.g. quota cap)

### DIFF
--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -93,6 +93,8 @@ const push = async (
     }
   }
 
+  const responseMessages: string[] = [];
+
   if (pushOptions?.experimentalPushAll) {
     const localeCount = Object.keys(local).length;
     log.log(
@@ -100,6 +102,7 @@ const push = async (
     );
     const res = await apiPushAll(accessKey, flattenAllTranslations(local), pushOptions);
     log.log(res.message);
+    responseMessages.push(res.message);
   } else {
     const length = Object.keys(remote).length;
     const progressbar = new cliProgress.SingleBar({
@@ -114,6 +117,7 @@ const push = async (
       progressbar.increment();
       const res = await apiPush(accessKey, locale, flattenTranslations(translations), pushOptions);
       messages.push([locale, res.message]);
+      responseMessages.push(res.message);
     }
     progressbar.stop();
     for (const [locale, message] of messages) {
@@ -122,6 +126,17 @@ const push = async (
   }
 
   log.log();
+
+  // Loco returns 200 OK with "Nothing updated" when an import is silently
+  // dropped (most commonly: project has hit its translation quota cap).
+  // Surface this as a real failure instead of pretending the push succeeded.
+  const allNoOp = responseMessages.every(m => /nothing updated/i.test(m));
+  if (allNoOp) {
+    log.error(
+      'Loco reported no changes despite a non-empty diff. Check your project on https://localise.biz for quota limits or other server-side issues.'
+    );
+    process.exit(1);
+  }
 
   log.warn(
     'Be kind to your translators, provide a note in the `Notes` field on Loco when there is not enough context.'

--- a/test/commands/push.test.ts
+++ b/test/commands/push.test.ts
@@ -281,6 +281,55 @@ describe('push command', () => {
     expect(mockLog.log).toHaveBeenCalledWith('4 translations imported, 2 new assets');
   });
 
+  test('errors when all locales return "Nothing updated" (per-locale path)', async () => {
+    const local = { en: { hello: 'Hello' }, es: { hello: 'Hola' } };
+    const remote = { en: {}, es: {} };
+    mockReadFiles.mockResolvedValue(local);
+    mockApiPull.mockResolvedValue(remote);
+    mockApiPush.mockResolvedValue({ status: 200, message: 'Nothing updated', locales: [] });
+    vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
+
+    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+
+    expect(mockLog.error).toHaveBeenCalledWith(
+      expect.stringContaining('no changes despite a non-empty diff')
+    );
+    expect(mockLog.success).not.toHaveBeenCalledWith('All done.');
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  test('errors when experimentalPushAll returns "Nothing updated"', async () => {
+    const local = { en: { hello: 'Hello' }, es: { hello: 'Hola' } };
+    const remote = { en: {}, es: {} };
+    mockReadFiles.mockResolvedValue(local);
+    mockApiPull.mockResolvedValue(remote);
+    mockApiPushAll.mockResolvedValue({ status: 200, message: 'Nothing updated', locales: [] });
+    vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
+
+    await expect(push({ experimentalPushAll: true }, mockProgram)).rejects.toThrow(ExitError);
+
+    expect(mockLog.error).toHaveBeenCalledWith(
+      expect.stringContaining('no changes despite a non-empty diff')
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  test('does not error when at least one locale reports changes', async () => {
+    const local = { en: { hello: 'Hello' }, es: { hello: 'Hola' } };
+    const remote = { en: {}, es: {} };
+    mockReadFiles.mockResolvedValue(local);
+    mockApiPull.mockResolvedValue(remote);
+    mockApiPush
+      .mockResolvedValueOnce({ status: 200, message: '1 new asset', locales: [] })
+      .mockResolvedValueOnce({ status: 200, message: 'Nothing updated', locales: [] });
+    vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
+
+    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+
+    expect(mockLog.success).toHaveBeenCalledWith('All done.');
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
   test('uses default per-locale push when experimentalPushAll is false', async () => {
     const local = { en: { hello: 'Hello' }, es: { hello: 'Hola' } };
     const remote = { en: {}, es: {} };


### PR DESCRIPTION
## Summary
Closes #22.

When a project hits its translation quota, Loco's import endpoint returns `200 OK` with body `{message: "Nothing updated"}` and silently drops the new translations. The CLI previously surfaced the message but then printed `✔ All done.`, making it look like the push succeeded when nothing was actually written.

This was reproduced end-to-end on a Free-tier project (2,000 translation cap):
- Local files contained 1,500 new keys
- Diff correctly identified them as additions
- Per-locale push returned `Nothing updated` for both locales
- CLI then printed `✔ All done.` 

After this PR, the same scenario logs a clear error pointing to the Loco dashboard and exits with code 1. Mixed responses (some locales succeed, others no-op) keep the original success path.

## Test plan
- [x] `pnpm test` passes (78 tests)
- [x] `pnpm lint`, `pnpm format:check`, `pnpm build` pass
- [x] On a project at quota cap, `loco-cli push --yes` with new keys exits 1 and prints the new error
- [x] On a healthy project, `loco-cli push` still prints `All done.` and exits 0
- [x] When some locales succeed and others return `Nothing updated`, the push is still considered successful (no false alarm)