### PR TITLE
chore: cleanup pass for OSS polish

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -12,7 +12,11 @@ const program = new Command('loco-cli')
   .option('-a, --access-key <key>', 'Loco API token')
   .option('-d, --locales-dir <path>', 'The folder in which the translations are stored.')
   .option('-N, --namespaces', 'Organize translations into namespaces')
-  .option('-m, --max-files <number>', 'Maximum number of modified files to display');
+  .option('-m, --max-files <number>', 'Maximum number of modified files to display')
+  .addHelpText(
+    'after',
+    '\nMost options can also be set in a loco.config.js file. See https://loco-cli.robrecht.me/configuration.'
+  );
 program
   .command('pull')
   .option('-y, --yes', 'Answer yes to all confirmation prompts', false)

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
     "email": "hello@robrecht.me",
     "url": "https://robrecht.me"
   },
-  "main": "./dist/cli.js",
   "bin": {
     "loco-cli": "./dist/cli.js"
   },
   "packageManager": "pnpm@10.28.2",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "build": "tsc",
     "docs:dev": "pnpm --filter @loco-cli/docs dev",
@@ -45,8 +47,7 @@
     "commander": "^14.0.3",
     "cosmiconfig": "^9.0.1",
     "deep-object-diff": "^1.1.9",
-    "inquirer": "^13.4.2",
-    "isomorphic-unfetch": "^4.0.2"
+    "inquirer": "^13.4.2"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       inquirer:
         specifier: ^13.4.2
         version: 13.4.2(@types/node@25.6.0)
-      isomorphic-unfetch:
-        specifier: ^4.0.2
-        version: 4.0.2
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1
@@ -1268,10 +1265,6 @@ packages:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1507,10 +1500,6 @@ packages:
       picomatch:
         optional: true
 
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1536,10 +1525,6 @@ packages:
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1722,9 +1707,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isomorphic-unfetch@4.0.2:
-    resolution: {integrity: sha512-1Yd+CF/7al18/N2BDbsLBcp6RO3tucSW+jcLq24dqdX5MNbCNTw1z4BsGsp4zNmjr/Izm2cs/cEqZPp4kvWSCA==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1984,17 +1966,8 @@ packages:
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
@@ -2400,9 +2373,6 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  unfetch@5.0.0:
-    resolution: {integrity: sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg==}
-
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -2607,10 +2577,6 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
-
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -3831,8 +3797,6 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
-  data-uri-to-buffer@4.0.1: {}
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -4093,11 +4057,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
-
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -4123,10 +4082,6 @@ snapshots:
   fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
-
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
 
   fsevents@2.3.3:
     optional: true
@@ -4421,11 +4376,6 @@ snapshots:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
-
-  isomorphic-unfetch@4.0.2:
-    dependencies:
-      node-fetch: 3.3.2
-      unfetch: 5.0.0
 
   js-tokens@4.0.0: {}
 
@@ -4959,15 +4909,7 @@ snapshots:
     dependencies:
       '@types/nlcst': 2.0.3
 
-  node-domexception@1.0.0: {}
-
   node-fetch-native@1.6.7: {}
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
 
   node-mock-http@1.0.4: {}
 
@@ -5502,8 +5444,6 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  unfetch@5.0.0: {}
-
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -5642,8 +5582,6 @@ snapshots:
       - msw
 
   web-namespaces@2.0.1: {}
-
-  web-streams-polyfill@3.3.3: {}
 
   which-pm-runs@1.1.0: {}
 

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -52,7 +52,7 @@ const push = async (
 
   if (!totalCount || (!deleteAbsent && totalCount === deletedCount)) {
     log.info(
-      `Pushing will not delete remote assets when the ${chalk.bold('delete-abscent')} flag is disabled`
+      `Pushing will not delete remote assets when the ${chalk.bold('delete-absent')} flag is disabled`
     );
     log.success('Everything up to date!');
     process.exit(0);
@@ -71,10 +71,10 @@ const push = async (
   if (!yes) {
     if (deletedCount) {
       if (deleteAbsent) {
-        log.warn(`${chalk.bold('delete-abscent')} enabled, proceed with caution!\n`);
+        log.warn(`${chalk.bold('delete-absent')} enabled, proceed with caution!\n`);
       } else {
         log.info(
-          `Pushing will not delete remote assets when the ${chalk.bold('delete-abscent')} flag is disabled\n`
+          `Pushing will not delete remote assets when the ${chalk.bold('delete-absent')} flag is disabled\n`
         );
       }
     }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,3 @@
-import fetch from 'isomorphic-unfetch';
 import {
   FlatTranslations,
   ImportResponse,
@@ -34,8 +33,10 @@ const fetchApi = async <T>(
 };
 
 export const apiPull = async (key: string, options: PullOptions = {}) => {
-  const translations = await fetchApi<Translations>(key, '/export/all.json', options);
-  const locales = await fetchApi<ProjectLocale[]>(key, '/locales');
+  const [translations, locales] = await Promise.all([
+    fetchApi<Translations>(key, '/export/all.json', options),
+    fetchApi<ProjectLocale[]>(key, '/locales')
+  ]);
   const firstLocale = locales[0];
   if (locales.length === 1 && firstLocale) {
     return { [firstLocale.code]: translations };

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -7,13 +7,10 @@ import {
   createMockResponse,
   createMockErrorResponse
 } from './mockdata/mockApi';
-
-vi.mock('isomorphic-unfetch');
-
-import fetch from 'isomorphic-unfetch';
 import { apiPull, apiPush, apiPushAll } from '../src/lib/api';
 
-const mockFetch = vi.mocked(fetch);
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
 
 beforeEach(() => {
   mockFetch.mockReset();

--- a/test/commands/push.test.ts
+++ b/test/commands/push.test.ts
@@ -158,7 +158,7 @@ describe('push command', () => {
     await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
 
     expect(mockLog.warn).toHaveBeenCalledWith(
-      expect.stringContaining('delete-abscent')
+      expect.stringContaining('delete-absent')
     );
   });
 
@@ -171,7 +171,7 @@ describe('push command', () => {
     await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
 
     expect(mockLog.info).toHaveBeenCalledWith(
-      expect.stringContaining('delete-abscent')
+      expect.stringContaining('delete-absent')
     );
     expect(mockLog.success).toHaveBeenCalledWith('Everything up to date!');
     expect(mockApiPush).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Fix `delete-abscent` typo in `push` warning messages (user-facing output)
- Drop `isomorphic-unfetch`; use Node's native `fetch` and declare `engines.node: ">=18"`
- Parallelize the two `apiPull` requests with `Promise.all`
- Remove the `main` field from `package.json` — `loco-cli` is bin-only
- Delete dead `src/app/` directory (empty since 2022)
- Surface `loco.config.js` in `loco-cli --help` output

## Test plan
- [x] `pnpm install` resolves without `isomorphic-unfetch`
- [x] `pnpm build && pnpm test && pnpm lint && pnpm format:check` all pass
- [x] `node ./dist/cli.js --help` shows the config-file hint at the bottom
- [x] A real `push` against a Loco project still pulls + diffs + uploads correctly
- [x] Warning messages on `push` now read `delete-absent`, not `delete-abscent`