### PR TITLE
fix: stop swallowing failure exit codes

### DIFF
--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -22,7 +22,7 @@ const pull = async ({ yes }: CommandOptions, program: Command) => {
   const { added, updated, deleted, totalCount: count } = diff(local, remote);
   if (!count) {
     log.success('Everything up to date!');
-    process.exit(0);
+    return;
   }
 
   log.log(`
@@ -41,13 +41,12 @@ const pull = async ({ yes }: CommandOptions, program: Command) => {
 
     if (!confirm) {
       log.error('Nothing pulled');
-      process.exit(0);
+      return;
     }
   }
 
   writeFiles(remote, options);
   log.success(`Wrote files to ${chalk.bold(localesDir)}.`);
-  process.exit(0);
 };
 
 export default pull;

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -9,6 +9,7 @@ import { getGlobalOptions } from '../util/options';
 import { printDiff } from '../util/print';
 import { flattenTranslations, flattenAllTranslations } from '../lib/dotObject';
 import { log } from '../util/logger';
+import { CliError } from '../util/errors';
 
 interface CommandOptions {
   yes?: boolean;
@@ -55,7 +56,7 @@ const push = async (
       `Pushing will not delete remote assets when the ${chalk.bold('delete-absent')} flag is disabled`
     );
     log.success('Everything up to date!');
-    process.exit(0);
+    return;
   }
 
   log.log(`
@@ -89,7 +90,7 @@ const push = async (
 
     if (!confirm) {
       log.error('Nothing pushed');
-      process.exit(0);
+      return;
     }
   }
 
@@ -135,14 +136,13 @@ const push = async (
     log.error(
       'Loco reported no changes despite a non-empty diff. Check your project on https://localise.biz for quota limits or other server-side issues.'
     );
-    process.exit(1);
+    throw new CliError('push: no-op');
   }
 
   log.warn(
     'Be kind to your translators, provide a note in the `Notes` field on Loco when there is not enough context.'
   );
   log.success('All done.');
-  process.exit(0);
 };
 
 export default push;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -7,6 +7,7 @@ import { diff } from '../lib/diff';
 import chalk from 'chalk';
 import { printDiff } from '../util/print';
 import { log } from '../util/logger';
+import { CliError } from '../util/errors';
 
 interface CommandOptions {
   direction: 'remote' | 'local' | 'both';
@@ -29,7 +30,7 @@ const status = async ({ direction }: CommandOptions, program: Command) => {
 
   if (!totalCount) {
     log.success('Everything up to date!');
-    process.exit(0);
+    return;
   }
 
   let isDirty = false;
@@ -66,11 +67,9 @@ ${printDiff({ deleted, maxFiles })}
   }
 
   if (isDirty) {
-    process.exit(1);
-  } else {
-    log.success('Everything up to date!');
-    process.exit(0);
+    throw new CliError('status: dirty');
   }
+  log.success('Everything up to date!');
 };
 
 export default status;

--- a/src/lib/readFiles.ts
+++ b/src/lib/readFiles.ts
@@ -2,12 +2,13 @@ import { existsSync, readdirSync, statSync } from 'fs';
 import { readFile } from 'fs';
 import { join } from 'path';
 import { Translations } from '../../types';
+import { CliError } from '../util/errors';
 import { log } from '../util/logger';
 
 const readJSON = async (path: string): Promise<Record<string, string>> => {
   if (!existsSync(path)) {
     log.error(`File not found: ${path}`);
-    process.exit(1);
+    throw new CliError(`File not found: ${path}`);
   }
 
   return new Promise((resolve, reject) => {
@@ -27,7 +28,7 @@ const readFilesInDir = async (
   const res: Record<string, string> = {};
   if (!existsSync(path)) {
     log.error(`Directory not found: "${path}"`);
-    process.exit(1);
+    throw new CliError(`Directory not found: ${path}`);
   }
   const files = readdirSync(path);
 

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -1,0 +1,6 @@
+export class CliError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CliError';
+  }
+}

--- a/src/util/handleAsyncErrors.ts
+++ b/src/util/handleAsyncErrors.ts
@@ -1,9 +1,15 @@
 import chalk from 'chalk';
+import { CliError } from './errors';
 
 export const handleAsyncErrors = <T extends unknown[]>(fn: (...args: T) => Promise<void>) => {
   return (...args: T) =>
     fn(...args).catch((error: Error) => {
-      if (error.message === 'HTTPError: 401 Authorization Required') {
+      process.exitCode = 1;
+      // CliError: caller already printed a user-facing message
+      if (error instanceof CliError) {
+        return;
+      }
+      if (/^HTTPError: 401\b/.test(error.message)) {
         console.log(
           `\n${chalk.red(
             '✗ Invalid access key. Make sure to use a Full access key.\nSee https://localise.biz/help/developers/api-keys#writeable for more info.\n'

--- a/src/util/options.ts
+++ b/src/util/options.ts
@@ -1,12 +1,13 @@
 import { Command } from 'commander';
 import type { Config } from '../../types';
 import { readConfig } from './config';
+import { CliError } from './errors';
 import { log } from './logger';
 
 export const getGlobalOptions = async (program: Command): Promise<Config> => {
   if (!program.parent) {
     log.error('Something went wrong. Sorry!');
-    process.exit(1);
+    throw new CliError('options: no parent command');
   }
   const cliOptions = program.parent.opts<Partial<Config>>();
 
@@ -18,7 +19,7 @@ export const getGlobalOptions = async (program: Command): Promise<Config> => {
     log.error(
       'No personal access token found. Provide one with the `-a` option, or in the config file.'
     );
-    process.exit(1);
+    throw new CliError('options: missing access key');
   }
 
   if (hasFileOptions) {

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { Command } from 'commander';
 
 vi.mock('../../src/util/options');
@@ -32,16 +32,6 @@ const defaultOptions = {
   maxFiles: 20
 };
 
-// Custom error to signal process.exit was called
-class ExitError extends Error {
-  constructor(public code: number) {
-    super(`process.exit(${code})`);
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let mockExit: any;
-
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetGlobalOptions.mockResolvedValue(defaultOptions);
@@ -50,26 +40,17 @@ beforeEach(() => {
   mockLog.error = vi.fn();
   mockLog.warn = vi.fn();
   mockLog.info = vi.fn();
-  // Make process.exit throw to stop execution
-  mockExit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-    throw new ExitError(code ?? 0);
-  }) as never);
-});
-
-afterEach(() => {
-  mockExit.mockRestore();
 });
 
 describe('pull command', () => {
-  test('exits 0 when no changes', async () => {
+  test('returns when no changes', async () => {
     const translations = { en: { hello: 'Hello' } };
     mockReadFiles.mockResolvedValue(translations);
     mockApiPull.mockResolvedValue(translations);
 
-    await expect(pull({}, mockProgram)).rejects.toThrow(ExitError);
+    await pull({}, mockProgram);
 
     expect(mockLog.success).toHaveBeenCalledWith('Everything up to date!');
-    expect(mockExit).toHaveBeenCalledWith(0);
     expect(mockWriteFiles).not.toHaveBeenCalled();
   });
 
@@ -80,7 +61,7 @@ describe('pull command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(pull({}, mockProgram)).rejects.toThrow(ExitError);
+    await pull({}, mockProgram);
 
     expect(mockInquirer.prompt).toHaveBeenCalled();
   });
@@ -92,7 +73,7 @@ describe('pull command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(pull({}, mockProgram)).rejects.toThrow(ExitError);
+    await pull({}, mockProgram);
 
     expect(mockWriteFiles).toHaveBeenCalledWith(remote, defaultOptions);
     expect(mockLog.success).toHaveBeenCalledWith(expect.stringContaining('Wrote files'));
@@ -105,11 +86,10 @@ describe('pull command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: false });
 
-    await expect(pull({}, mockProgram)).rejects.toThrow(ExitError);
+    await pull({}, mockProgram);
 
     expect(mockWriteFiles).not.toHaveBeenCalled();
     expect(mockLog.error).toHaveBeenCalledWith('Nothing pulled');
-    expect(mockExit).toHaveBeenCalledWith(0);
   });
 
   test('skips prompt with --yes flag', async () => {
@@ -118,7 +98,7 @@ describe('pull command', () => {
     mockReadFiles.mockResolvedValue(local);
     mockApiPull.mockResolvedValue(remote);
 
-    await expect(pull({ yes: true }, mockProgram)).rejects.toThrow(ExitError);
+    await pull({ yes: true }, mockProgram);
 
     expect(mockInquirer.prompt).not.toHaveBeenCalled();
     expect(mockWriteFiles).toHaveBeenCalledWith(remote, defaultOptions);
@@ -138,7 +118,7 @@ describe('pull command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: false });
 
-    await expect(pull({}, mockProgram)).rejects.toThrow(ExitError);
+    await pull({}, mockProgram);
 
     expect(mockLog.log).toHaveBeenCalledWith(expect.stringContaining('Pulling will have the following effect'));
   });

--- a/test/commands/push.test.ts
+++ b/test/commands/push.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { Command } from 'commander';
 
 vi.mock('../../src/util/options');
@@ -20,6 +20,7 @@ import { getGlobalOptions } from '../../src/util/options';
 import { readFiles } from '../../src/lib/readFiles';
 import { apiPull, apiPush, apiPushAll } from '../../src/lib/api';
 import { log } from '../../src/util/logger';
+import { CliError } from '../../src/util/errors';
 import inquirer from 'inquirer';
 import push from '../../src/commands/push';
 
@@ -40,16 +41,6 @@ const defaultOptions = {
   maxFiles: 20
 };
 
-// Custom error to signal process.exit was called
-class ExitError extends Error {
-  constructor(public code: number) {
-    super(`process.exit(${code})`);
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let mockExit: any;
-
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetGlobalOptions.mockResolvedValue(defaultOptions);
@@ -60,25 +51,17 @@ beforeEach(() => {
   mockLog.info = vi.fn();
   mockApiPush.mockResolvedValue({ status: 200, message: '1 translation imported', locales: [] });
   mockApiPushAll.mockResolvedValue({ status: 200, message: '1 translation imported', locales: [] });
-  mockExit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-    throw new ExitError(code ?? 0);
-  }) as never);
-});
-
-afterEach(() => {
-  mockExit.mockRestore();
 });
 
 describe('push command', () => {
-  test('exits 0 when no changes', async () => {
+  test('returns when no changes', async () => {
     const translations = { en: { hello: 'Hello' } };
     mockReadFiles.mockResolvedValue(translations);
     mockApiPull.mockResolvedValue(translations);
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockLog.success).toHaveBeenCalledWith('Everything up to date!');
-    expect(mockExit).toHaveBeenCalledWith(0);
     expect(mockApiPush).not.toHaveBeenCalled();
   });
 
@@ -87,7 +70,7 @@ describe('push command', () => {
     mockReadFiles.mockResolvedValue(translations);
     mockApiPull.mockResolvedValue(translations);
 
-    await expect(push({ status: 'fuzzy' }, mockProgram)).rejects.toThrow(ExitError);
+    await push({ status: 'fuzzy' }, mockProgram);
 
     expect(mockLog.warn).toHaveBeenCalledWith(
       expect.stringContaining('status option is removed')
@@ -99,7 +82,7 @@ describe('push command', () => {
     mockReadFiles.mockResolvedValue(translations);
     mockApiPull.mockResolvedValue(translations);
 
-    await expect(push({ tag: 'new' }, mockProgram)).rejects.toThrow(ExitError);
+    await push({ tag: 'new' }, mockProgram);
 
     expect(mockLog.warn).toHaveBeenCalledWith(
       expect.stringContaining('tag option is removed')
@@ -113,7 +96,7 @@ describe('push command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockApiPush).toHaveBeenCalledTimes(2);
     expect(mockApiPush).toHaveBeenCalledWith('test-key', 'en', { hello: 'Hello' }, {});
@@ -127,7 +110,7 @@ describe('push command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockInquirer.prompt).toHaveBeenCalled();
   });
@@ -138,7 +121,7 @@ describe('push command', () => {
     mockReadFiles.mockResolvedValue(local);
     mockApiPull.mockResolvedValue(remote);
 
-    await expect(push({ yes: true }, mockProgram)).rejects.toThrow(ExitError);
+    await push({ yes: true }, mockProgram);
 
     expect(mockInquirer.prompt).not.toHaveBeenCalled();
     expect(mockApiPush).toHaveBeenCalled();
@@ -155,7 +138,7 @@ describe('push command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: false });
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockLog.warn).toHaveBeenCalledWith(
       expect.stringContaining('delete-absent')
@@ -168,7 +151,7 @@ describe('push command', () => {
     mockReadFiles.mockResolvedValue(local);
     mockApiPull.mockResolvedValue(remote);
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockLog.info).toHaveBeenCalledWith(
       expect.stringContaining('delete-absent')
@@ -184,7 +167,7 @@ describe('push command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: false });
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockLog.error).toHaveBeenCalledWith('Nothing pushed');
     expect(mockApiPush).not.toHaveBeenCalled();
@@ -201,7 +184,7 @@ describe('push command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockApiPush).toHaveBeenCalledWith(
       'test-key',
@@ -218,7 +201,7 @@ describe('push command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({ experimentalPushAll: true }, mockProgram)).rejects.toThrow(ExitError);
+    await push({ experimentalPushAll: true }, mockProgram);
 
     expect(mockApiPushAll).toHaveBeenCalledTimes(1);
     expect(mockApiPushAll).toHaveBeenCalledWith(
@@ -240,7 +223,7 @@ describe('push command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockApiPushAll).toHaveBeenCalledTimes(1);
     expect(mockApiPush).not.toHaveBeenCalled();
@@ -256,7 +239,7 @@ describe('push command', () => {
       .mockResolvedValueOnce({ status: 200, message: 'Nothing updated', locales: [] });
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockLog.log).toHaveBeenCalledWith(expect.stringContaining('en'));
     expect(mockLog.log).toHaveBeenCalledWith(expect.stringContaining('1 new asset'));
@@ -276,12 +259,12 @@ describe('push command', () => {
     });
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({ experimentalPushAll: true }, mockProgram)).rejects.toThrow(ExitError);
+    await push({ experimentalPushAll: true }, mockProgram);
 
     expect(mockLog.log).toHaveBeenCalledWith('4 translations imported, 2 new assets');
   });
 
-  test('errors when all locales return "Nothing updated" (per-locale path)', async () => {
+  test('throws CliError when all locales return "Nothing updated" (per-locale path)', async () => {
     const local = { en: { hello: 'Hello' }, es: { hello: 'Hola' } };
     const remote = { en: {}, es: {} };
     mockReadFiles.mockResolvedValue(local);
@@ -289,16 +272,15 @@ describe('push command', () => {
     mockApiPush.mockResolvedValue({ status: 200, message: 'Nothing updated', locales: [] });
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await expect(push({}, mockProgram)).rejects.toThrow(CliError);
 
     expect(mockLog.error).toHaveBeenCalledWith(
       expect.stringContaining('no changes despite a non-empty diff')
     );
     expect(mockLog.success).not.toHaveBeenCalledWith('All done.');
-    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
-  test('errors when experimentalPushAll returns "Nothing updated"', async () => {
+  test('throws CliError when experimentalPushAll returns "Nothing updated"', async () => {
     const local = { en: { hello: 'Hello' }, es: { hello: 'Hola' } };
     const remote = { en: {}, es: {} };
     mockReadFiles.mockResolvedValue(local);
@@ -306,12 +288,11 @@ describe('push command', () => {
     mockApiPushAll.mockResolvedValue({ status: 200, message: 'Nothing updated', locales: [] });
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({ experimentalPushAll: true }, mockProgram)).rejects.toThrow(ExitError);
+    await expect(push({ experimentalPushAll: true }, mockProgram)).rejects.toThrow(CliError);
 
     expect(mockLog.error).toHaveBeenCalledWith(
       expect.stringContaining('no changes despite a non-empty diff')
     );
-    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   test('does not error when at least one locale reports changes', async () => {
@@ -324,10 +305,9 @@ describe('push command', () => {
       .mockResolvedValueOnce({ status: 200, message: 'Nothing updated', locales: [] });
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockLog.success).toHaveBeenCalledWith('All done.');
-    expect(mockExit).toHaveBeenCalledWith(0);
   });
 
   test('uses default per-locale push when experimentalPushAll is false', async () => {
@@ -337,7 +317,7 @@ describe('push command', () => {
     mockApiPull.mockResolvedValue(remote);
     vi.mocked(mockInquirer.prompt).mockResolvedValue({ confirm: true });
 
-    await expect(push({}, mockProgram)).rejects.toThrow(ExitError);
+    await push({}, mockProgram);
 
     expect(mockApiPush).toHaveBeenCalledTimes(2);
     expect(mockApiPushAll).not.toHaveBeenCalled();

--- a/test/commands/status.test.ts
+++ b/test/commands/status.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { Command } from 'commander';
 
 vi.mock('../../src/util/options');
@@ -10,6 +10,7 @@ import { getGlobalOptions } from '../../src/util/options';
 import { readFiles } from '../../src/lib/readFiles';
 import { apiPull } from '../../src/lib/api';
 import { log } from '../../src/util/logger';
+import { CliError } from '../../src/util/errors';
 import status from '../../src/commands/status';
 
 const mockGetGlobalOptions = vi.mocked(getGlobalOptions);
@@ -26,16 +27,6 @@ const defaultOptions = {
   maxFiles: 20
 };
 
-// Custom error to signal process.exit was called
-class ExitError extends Error {
-  constructor(public code: number) {
-    super(`process.exit(${code})`);
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let mockExit: any;
-
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetGlobalOptions.mockResolvedValue(defaultOptions);
@@ -44,36 +35,26 @@ beforeEach(() => {
   mockLog.error = vi.fn();
   mockLog.warn = vi.fn();
   mockLog.info = vi.fn();
-  mockExit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-    throw new ExitError(code ?? 0);
-  }) as never);
-});
-
-afterEach(() => {
-  mockExit.mockRestore();
 });
 
 describe('status command', () => {
-  test('exits 0 when no diff', async () => {
+  test('returns when no diff', async () => {
     const translations = { en: { hello: 'Hello' } };
     mockReadFiles.mockResolvedValue(translations);
     mockApiPull.mockResolvedValue(translations);
 
-    await expect(status({ direction: 'both' }, mockProgram)).rejects.toThrow(ExitError);
+    await status({ direction: 'both' }, mockProgram);
 
     expect(mockLog.success).toHaveBeenCalledWith('Everything up to date!');
-    expect(mockExit).toHaveBeenCalledWith(0);
   });
 
-  test('exits 1 when diff exists', async () => {
+  test('throws CliError when diff exists', async () => {
     const local = { en: { hello: 'Hello' } };
     const remote = { en: { hello: 'Hello', bye: 'Goodbye' } };
     mockReadFiles.mockResolvedValue(local);
     mockApiPull.mockResolvedValue(remote);
 
-    await expect(status({ direction: 'both' }, mockProgram)).rejects.toThrow(ExitError);
-
-    expect(mockExit).toHaveBeenCalledWith(1);
+    await expect(status({ direction: 'both' }, mockProgram)).rejects.toThrow(CliError);
   });
 
   test('filters by direction=local shows only local changes', async () => {
@@ -82,9 +63,8 @@ describe('status command', () => {
     mockReadFiles.mockResolvedValue(local);
     mockApiPull.mockResolvedValue(remote);
 
-    await expect(status({ direction: 'local' }, mockProgram)).rejects.toThrow(ExitError);
+    await expect(status({ direction: 'local' }, mockProgram)).rejects.toThrow(CliError);
 
-    // With direction=local, only updated and deleted are shown (not added)
     expect(mockLog.log).toHaveBeenCalled();
   });
 
@@ -94,9 +74,8 @@ describe('status command', () => {
     mockReadFiles.mockResolvedValue(local);
     mockApiPull.mockResolvedValue(remote);
 
-    await expect(status({ direction: 'remote' }, mockProgram)).rejects.toThrow(ExitError);
+    await expect(status({ direction: 'remote' }, mockProgram)).rejects.toThrow(CliError);
 
-    // With direction=remote, only added is shown
     expect(mockLog.log).toHaveBeenCalled();
   });
 
@@ -106,9 +85,8 @@ describe('status command', () => {
     mockReadFiles.mockResolvedValue(local);
     mockApiPull.mockResolvedValue(remote);
 
-    await expect(status({ direction: 'both' }, mockProgram)).rejects.toThrow(ExitError);
+    await expect(status({ direction: 'both' }, mockProgram)).rejects.toThrow(CliError);
 
-    expect(mockExit).toHaveBeenCalledWith(1);
     expect(mockLog.log).toHaveBeenCalled();
   });
 
@@ -121,7 +99,7 @@ describe('status command', () => {
     mockReadFiles.mockResolvedValue(translations);
     mockApiPull.mockResolvedValue(translations);
 
-    await expect(status({ direction: 'both' }, mockProgram)).rejects.toThrow(ExitError);
+    await status({ direction: 'both' }, mockProgram);
 
     expect(mockApiPull).toHaveBeenCalledWith('test-key', { filter: 'mobile' });
   });

--- a/test/util/handleAsyncErrors.test.ts
+++ b/test/util/handleAsyncErrors.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleAsyncErrors } from '../../src/util/handleAsyncErrors';
+import { CliError } from '../../src/util/errors';
+
+describe('handleAsyncErrors', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = 0;
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+    consoleSpy.mockRestore();
+  });
+
+  test('leaves exitCode unchanged when the wrapped fn resolves', async () => {
+    const wrapped = handleAsyncErrors(async () => {});
+    await wrapped();
+    expect(process.exitCode).toBe(0);
+  });
+
+  test('sets exitCode to 1 on any thrown Error', async () => {
+    const wrapped = handleAsyncErrors(async () => {
+      throw new Error('boom');
+    });
+    await wrapped();
+    expect(process.exitCode).toBe(1);
+  });
+
+  test('sets exitCode to 1 on CliError without printing the generic message', async () => {
+    const wrapped = handleAsyncErrors(async () => {
+      throw new CliError('caller already logged');
+    });
+    await wrapped();
+    expect(process.exitCode).toBe(1);
+    // Generic "An unexpected error occurred" wrapper is suppressed for CliError
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  test('prints the access-key hint on a 401 HTTPError', async () => {
+    const wrapped = handleAsyncErrors(async () => {
+      throw new Error('HTTPError: 401 Unauthorized');
+    });
+    await wrapped();
+    expect(process.exitCode).toBe(1);
+    const printed = consoleSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(printed).toContain('Invalid access key');
+  });
+
+  test('prints the generic message on other errors', async () => {
+    const wrapped = handleAsyncErrors(async () => {
+      throw new Error('something else');
+    });
+    await wrapped();
+    expect(process.exitCode).toBe(1);
+    const printed = consoleSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(printed).toContain('An unexpected error occurred');
+    expect(printed).toContain('something else');
+  });
+});

--- a/test/util/options.test.ts
+++ b/test/util/options.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { Command } from 'commander';
 
 vi.mock('../../src/util/config');
@@ -6,20 +6,11 @@ vi.mock('../../src/util/logger');
 
 import { readConfig } from '../../src/util/config';
 import { log } from '../../src/util/logger';
+import { CliError } from '../../src/util/errors';
 import { getGlobalOptions } from '../../src/util/options';
 
 const mockReadConfig = vi.mocked(readConfig);
 const mockLog = vi.mocked(log);
-
-// Custom error to signal process.exit was called
-class ExitError extends Error {
-  constructor(public code: number) {
-    super(`process.exit(${code})`);
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let mockExit: any;
 
 const createMockProgram = (cliOptions: Record<string, unknown> = {}) => {
   return {
@@ -36,13 +27,6 @@ beforeEach(() => {
   mockLog.error = vi.fn();
   mockLog.warn = vi.fn();
   mockLog.info = vi.fn();
-  mockExit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-    throw new ExitError(code ?? 0);
-  }) as never);
-});
-
-afterEach(() => {
-  mockExit.mockRestore();
 });
 
 describe('getGlobalOptions', () => {
@@ -93,15 +77,14 @@ describe('getGlobalOptions', () => {
     expect(result.namespaces).toBe(true);
   });
 
-  test('exits when no accessKey', async () => {
+  test('throws CliError when no accessKey', async () => {
     mockReadConfig.mockResolvedValue({});
 
-    await expect(getGlobalOptions(createMockProgram({}))).rejects.toThrow(ExitError);
+    await expect(getGlobalOptions(createMockProgram({}))).rejects.toThrow(CliError);
 
     expect(mockLog.error).toHaveBeenCalledWith(
       expect.stringContaining('No personal access token found')
     );
-    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   test('accepts accessKey from CLI', async () => {
@@ -155,18 +138,17 @@ describe('getGlobalOptions', () => {
   test('does not log when no config file', async () => {
     mockReadConfig.mockResolvedValue({});
 
-    await expect(getGlobalOptions(createMockProgram({}))).rejects.toThrow(ExitError);
+    await expect(getGlobalOptions(createMockProgram({}))).rejects.toThrow(CliError);
 
     // Should not log about reading config file
     expect(mockLog.log).not.toHaveBeenCalledWith(expect.stringContaining('config file'));
   });
 
-  test('exits when program has no parent', async () => {
+  test('throws CliError when program has no parent', async () => {
     const programWithoutParent = {} as Command;
 
-    await expect(getGlobalOptions(programWithoutParent)).rejects.toThrow(ExitError);
+    await expect(getGlobalOptions(programWithoutParent)).rejects.toThrow(CliError);
 
     expect(mockLog.error).toHaveBeenCalledWith('Something went wrong. Sorry!');
-    expect(mockExit).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Summary
- `handleAsyncErrors` previously caught errors but never set a non-zero exit code — failed pulls/pushes silently passed in CI. It now always sets `process.exitCode = 1` on a caught error.
- Introduces `CliError` for the "we've already printed a friendly user-facing message, just exit 1" case. `handleAsyncErrors` recognizes it and skips the generic error wrapper.
- Removes every `process.exit(0|1)` call from command bodies (`pull`, `push`, `status`) and helpers (`getGlobalOptions`, `readFiles`). Successful paths just return; failure paths log + `throw new CliError(...)`.
- Tests no longer need the `ExitError` / `process.exit` spy workaround. Added 5 unit tests for `handleAsyncErrors` covering the regression.

## Test plan
- [x] `pnpm build && pnpm test && pnpm lint && pnpm format:check` all pass
- [x] `loco-cli status` with no diff exits 0
- [x] `loco-cli status` with a diff exits 1
- [x] `loco-cli pull` / `push` with a missing/invalid access key exits 1 (and prints the access-key hint)
- [x] `loco-cli pull` with `n` at the prompt exits 0 (user declined ≠ error)
- [x] `loco-cli push` against a quota-capped project (Loco returns "Nothing updated") exits 1 with the explanatory message