### PR TITLE
chore: bump pinned nodejs and pnpm versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 22.22.0
-pnpm 10.28.2
+nodejs 22.22.2
+pnpm 10.33.3

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "bin": {
     "loco-cli": "./dist/cli.js"
   },
-  "packageManager": "pnpm@10.28.2",
+  "packageManager": "pnpm@10.33.3",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- Bump `nodejs` from `22.22.0` to `22.22.2` (latest 22 LTS patch)
- Bump `pnpm` from `10.28.2` to `10.33.3` in both `.tool-versions` and `package.json` (`packageManager`)

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds with the new pnpm version
- [x] `pnpm test` passes
- [x] CI workflows pick up the new versions without changes